### PR TITLE
Prevent installing Changes.pod as $INC[...]/Set/Changes.pod

### DIFF
--- a/INSTALL.SKIP
+++ b/INSTALL.SKIP
@@ -1,0 +1,1 @@
+\bChanges\.pod$

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,5 @@
 Changes.pod
+INSTALL.SKIP
 LICENSE
 lib/Set/Object.pm
 lib/Set/Object/Weak.pm


### PR DESCRIPTION
Currently, `Changes.pod` installs into `@INC` using the traditional method used for installing  `*.pm` , `*.pl`, and `*.pod`

This is the simplest fix that works by filtering the `blib/` to `/` copy in ExtUtils::Install