### PR TITLE
use meta-spec 2, Moose -> dev.requires not runtime.recommends

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,15 +23,25 @@ WriteMakefile(
   ($ExtUtils::MakeMaker::VERSION gt '6.46' ?
    ('META_MERGE'  =>
     {
-      recommends => {
-	# deps of t/misc/more_leaks.t
-	'Test::LeakTrace' => 0,
-	'Moose'           => 0,
-      },
+      "meta-spec" => { version => 2 },
+      dynamic_config => 0,
       resources => {
-	license     => 'http://dev.perl.org/licenses/',
-	repository  => 'git://github.com/rurban/Set-Object.git',
-      }
+        repository => {
+          type => 'git',
+          url => 'git@github.com:rurban/Set-Object.git',
+          web => 'https://github.com/rurban/Set-Object',
+        },
+        license => [ 'http://dev.perl.org/licenses/' ],
+      },
+      prereqs => {
+        develop => {
+          requires => {
+            # deps of t/misc/more_leaks.t
+            'Test::LeakTrace' => 0,
+            'Moose'           => 0,
+          },
+        },
+      },
     }) : ()
   ),
   test => { TESTS => join(' ', glob('t/*/*.t')) },


### PR DESCRIPTION
As discussed on https://rt.cpan.org/Ticket/Display.html?id=134034

Cc: @briandfoy